### PR TITLE
fix(achievements): corregir sistema de logros — v4.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@ Historial de cambios estructurales y visuales del proyecto.
 
 ---
 
+## [4.2.0] - 2026-04-04
+
+### Fixed — Sistema de Logros
+- **Carga lazy rota**: `AchievementManager` se cargaba solo al hacer hover sobre el botón FAB. Cualquier logro disparado antes de ese hover (logo click, búsquedas, giros de ruleta, abrir juegos) se perdía para siempre. Ahora se carga con `requestIdleCallback` al inicio de sesión, disponible en ~500ms.
+- **Contadores reseteados**: `rouletteSpins` y `colorChanges` se reiniciaban a 0 en cada carga de página, ignorando el progreso persistido en localStorage. Los logros `Ludópata` e `Indeciso` requerían completar toda la cuenta en una sola sesión.
+- **`window_shopper` bloqueado**: La condición usaba `=== 10` en vez de `>= 10`. Con 11+ juegos abiertos sin ninguna descarga el logro nunca se desbloqueaba.
+- **`DOWNLOAD_CLICK` sin trackear**: Los botones generados desde el array `game.buttons[]` no tenían la clase `btn-download-track`, por lo que el contador de descargas nunca incrementaba (rompía también `window_shopper`).
+- **Doble `init()`**: Se agrega flag `_initialized` para evitar que el módulo de logros se inicialice más de una vez si el script ya estaba en caché.
+
+### Changed
+- **Speedrunner**: Umbral de tiempo ampliado a **60 segundos** (antes: 30 s) para que el wlogro sea alcanzable de forma legítima.
+
+---
+
 ## [4.1.0] - 2026-03-31
 
 ### Added

--- a/assets/js/features/achievements/main.js
+++ b/assets/js/features/achievements/main.js
@@ -30,7 +30,7 @@ const AchievementManager = (() => {
         { id: 'window_shopper', title: 'Mirar y No Tocar', desc: 'Abriste 10 juegos sin descargar ninguno.', icon: '👀' },
 
         // Súper Secreto — solo visible si se desbloquea
-        { id: 'speedrunner', title: 'SPEEDRUNNER', desc: 'Completaste todos los logros en menos de 30 segundos. Tocá pasto.', icon: '⚡', secret: true }
+        { id: 'speedrunner', title: 'SPEEDRUNNER', desc: 'Completaste todos los logros en menos de 1 minuto. Tocá pasto.', icon: '⚡', secret: true }
     ];
 
     // === ESTADO ===
@@ -137,9 +137,7 @@ const AchievementManager = (() => {
             } else {
                 unlocked = new Set(saved.unlocked || []);
                 stats = { ...stats, ...(saved.stats || {}) };
-                // Los giros de ruleta y cambios de color se resetean por sesión
-                stats.rouletteSpins = 0;
-                stats.colorChanges = 0;
+                // Los contadores persisten entre sesiones para acumularse correctamente
                 speedrun = { ...speedrun, ...(saved.speedrun || {}) };
             }
         } catch (e) {
@@ -179,10 +177,9 @@ const AchievementManager = (() => {
         if (unlockedNonSecret === nonSecretCount && !speedrun.completionTime) {
             speedrun.completionTime = Date.now();
 
-            // Si se completó en menos de ~31s, desbloquear "Speedrunner"
-            // (31s porque la UI muestra segundos redondeados hacia abajo)
+            // Si se completó en menos de 1 minuto, desbloquear "Speedrunner"
             const duration = speedrun.completionTime - speedrun.startTime;
-            if (duration < 31000) {
+            if (duration < 60000) {
                 setTimeout(() => unlock('speedrunner'), 1000); // Delay dramático
             }
         }
@@ -283,8 +280,9 @@ const AchievementManager = (() => {
                 stats.lastGameOpen = now;
 
                 stats.gamesOpened++;
-                // Logro: Mirar y No Tocar (10 juegos, 0 descargas)
-                if (stats.gamesOpened === 10 && stats.downloadsClicked === 0) unlock('window_shopper');
+                // Logro: Mirar y No Tocar (10+ juegos, 0 descargas)
+                // >= en vez de === para que funcione aunque el usuario abra más de 10
+                if (stats.gamesOpened >= 10 && stats.downloadsClicked === 0) unlock('window_shopper');
                 break;
 
             case 'DOWNLOAD_CLICK':
@@ -413,7 +411,8 @@ const AchievementManager = (() => {
         unlock,
         trackEvent,
         getStats,
-        reset
+        reset,
+        _initialized: false
     };
 
 })();

--- a/assets/js/games/detail.js
+++ b/assets/js/games/detail.js
@@ -65,7 +65,8 @@ const GameDetail = (() => {
                 if (style === 'primary') css = 'btn btn-primary';
                 if (style === 'secondary') css = 'btn btn-secondary';
 
-                html += `<a href="${url}" target="_blank" class="${css}">${label}</a>`;
+                // Agregar btn-download-track a todos para que DOWNLOAD_CLICK se trackee siempre
+                html += `<a href="${url}" target="_blank" class="${css} btn-download-track">${label}</a>`;
             });
         } else {
             if (game.downloadUrl) html += `<a href="${game.downloadUrl}" target="_blank" class="btn btn-primary btn-download-track">Descargar</a>`;

--- a/assets/js/lazy-loader.js
+++ b/assets/js/lazy-loader.js
@@ -75,22 +75,26 @@ document.addEventListener('DOMContentLoaded', () => {
         btnMiniGames.addEventListener('click', openMiniGames);
     }
 
-    // 2. Logros (Modal explícito)
-    const btnAchievements = document.getElementById('btnAchievementsFab');
-    if (btnAchievements) {
-        const loadAchievements = async () => {
-            try {
-                await loadScript('assets/js/features/achievements/main.js');
-                if (typeof AchievementManager !== 'undefined') {
-                    AchievementManager.init();
-                }
-            } catch (e) {
-                console.error("Error loading achievements:", e);
+    // 2. Logros — se cargan de forma eager al inicio (no lazy)
+    // El archivo es liviano (~15kb) y otros módulos (theme, settings, router)
+    // necesitan AchievementManager disponible desde el primer evento del usuario.
+    const loadAchievements = async () => {
+        try {
+            await loadScript('assets/js/features/achievements/main.js');
+            if (typeof AchievementManager !== 'undefined' && !AchievementManager._initialized) {
+                AchievementManager.init();
+                AchievementManager._initialized = true;
             }
-        };
+        } catch (e) {
+            console.error("Error loading achievements:", e);
+        }
+    };
 
-        btnAchievements.addEventListener('mouseenter', loadAchievements, { once: true });
-        btnAchievements.addEventListener('touchstart', loadAchievements, { once: true });
+    // Cargar en idle callback para no bloquear el FCP pero estar disponible rápido
+    if ('requestIdleCallback' in window) {
+        window.requestIdleCallback(loadAchievements, { timeout: 500 });
+    } else {
+        setTimeout(loadAchievements, 100);
     }
 
     // 3. Deferred Scripts (Free Games)


### PR DESCRIPTION
Bugs corregidos:
- AchievementManager se cargaba lazy al hover del FAB; ahora usa requestIdleCallback (~500ms)
- rouletteSpins y colorChanges se reseteaban a 0 en cada recarga (ignorando localStorage)
- window_shopper usaba === 10 en vez de >= 10 (no se desbloqueaba con 11+ juegos)
- Botones de game.buttons[] no tenian clase btn-download-track; DOWNLOAD_CLICK nunca trackeba
- Agregado flag _initialized para evitar doble AchievementManager.init()

Cambios:
- Speedrunner: umbral ampliado de 30s a 60s